### PR TITLE
Remove "http:" from bootstrap stylesheet url at index.html (gh-pages)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>HAProxy Documentation Converter</title>
-		<link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" />
+		<link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" />
 		<link href="css/page.css" rel="stylesheet" />
 	</head>
 	<body>


### PR DESCRIPTION
To avoid blocking this stylesheet by browsers when page is being opened via https