### PR TITLE
keyword detection: consistently allow spaces in argument names

### DIFF
--- a/parser/keyword.py
+++ b/parser/keyword.py
@@ -8,7 +8,7 @@ class KeyWordParser(parser.Parser):
         self.keywordPattern = re.compile(r'^(%s%s)(%s)' % (
             '([a-z0-9\-\+_\.]*[a-z0-9\-\+_)])', # keyword
             '( [a-z0-9\-_]+)*',                  # subkeywords
-            '(\([^ ]*\))?',   # arg (ex: (<backend>), (<frontend>/<backend>), (<offset1>,<length>[,<offset2>]) ...
+            '(\([^)]*\))?',   # arg (ex: (<backend>), (<frontend>/<backend>), (<offset1>,<length>[,<offset2>]) ...
         ))
 
     def parse(self, line):


### PR DESCRIPTION
When keywords are parsed, spaces in argument names are not handled
consistently.

The following is parsed correctly:
  group <group name>

While the following isn't:
  unset-var(<var name>)

With this commit the latter would be parsed. Note that it would also
allow things such as:
  ipmask(<mask4>, [<mask6>])
  hmac(<algorithm>, <key>)

Both of these are not correct in that a space after the period
would prevent the config from being parsed by haproxy, but these
examples were in the actual documentation not long ago, and when
parsed by haproxy-dconv this makes them not searchable and not
correctly formatted in the html.