### PR TITLE
Add `|` to subkeywords regex

### DIFF
--- a/parser/keyword.py
+++ b/parser/keyword.py
@@ -7,7 +7,7 @@ class KeyWordParser(parser.Parser):
         parser.Parser.__init__(self, pctxt)
         self.keywordPattern = re.compile(r'^(%s%s)(%s)' % (
             '([a-z0-9\-\+_\.]*[a-z0-9\-\+_)])', # keyword
-            '( [a-z0-9\-_]+)*',                  # subkeywords
+            '( [a-z0-9\-_\|]+)*',                  # subkeywords
             '(\([^ ]*\))?',   # arg (ex: (<backend>), (<frontend>/<backend>), (<offset1>,<length>[,<offset2>]) ...
         ))
 


### PR DESCRIPTION
Because of the new `http-request set-timeout server|tunnel ` possibility should the sub keyword regex be extended to with `|`