### PR TITLE
Use absolute `https://` URLs instead of protocol-relative URLs for ex…

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>${headers['title']} ${headers['version']} - ${headers['subtitle']}</title>
-		<link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" />
-		<link href="//raw.githubusercontent.com/thomaspark/bootswatch/v3.3.7/cerulean/bootstrap.min.css" rel="stylesheet" />
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" />
+		<link href="https://raw.githubusercontent.com/thomaspark/bootswatch/v3.3.7/cerulean/bootstrap.min.css" rel="stylesheet" />
 		<link href="${base}css/page.css?${version}" rel="stylesheet" />
 	</head>
 	<body>
@@ -113,8 +113,8 @@
 		</div>
 		<!-- /#wrapper -->
 
-		<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/js/bootstrap.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/js/bootstrap.min.js"></script>
 		<script>
 			function filterKeywords(text) {
 				$('.letter').each(function(idx1, letter) {


### PR DESCRIPTION
…ternal assets

Protocol-relative URLs break if the documentation is tested using the
`file:///` scheme.