### PR TITLE
Add the link to the wiki page

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -28,6 +28,9 @@
 					%endfor
 				</ul>
 				<ul class="nav navbar-nav">
+					<li><a href="https://github.com/haproxy/wiki/wiki">Wiki</a></li>
+				</ul>
+				<ul class="nav navbar-nav">
 					<li><a href="http://www.haproxy.org/">HAProxy Home Page</a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
Add the link to the github wiki page between the generated links and the "HAProxy Home Page" link.